### PR TITLE
feature/release128 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-chainbridge.9
+
+- integrate with chainbridge
+
 # v0.9.18-rum.8
 
 - update unstake strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-chainbridge.15
+
+- update derive substrate address from evm address
+
 # v0.9.18-chainbridge.14
 
 - use agent to verify ecdsa signature directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-chainbridge.12
+
+- update chainbridge
+
 # v0.9.18-chainbridge.11
 
 - update chainbridge agents, add storage of ethereum nonce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-chainbridge.14
+
+- use agent to verify ecdsa signature directly
+
 # v0.9.18-chainbridge.13
 
 - update chainbridge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-chainbridge.13
+
+- update chainbridge
+
 # v0.9.18-chainbridge.12
 
 - update chainbridge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-chainbridge.10
+
+- integrate with chainbridge
+
 # v0.9.18-chainbridge.9
 
 - integrate with chainbridge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-rum.9
+
+- integrate with chainbridge
+
 # v0.9.18-chainbridge.15
 
 - update derive substrate address from evm address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.9.18-chainbridge.11
+
+- update chainbridge agents, add storage of ethereum nonce
+
 # v0.9.18-chainbridge.10
 
 - integrate with chainbridge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4330,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4331,11 +4331,12 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-agent"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "frame-support",
  "frame-system",
  "fuso-support",
+ "hex",
  "log",
  "pallet-balances",
  "pallet-transaction-payment",
@@ -4351,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4370,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4388,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4409,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#9997b322b9bd8766bb0d8bd0804d506d10d01f2d"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,6 +4293,7 @@ name = "pallet-chainbridge"
 version = "0.1.0"
 source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "fuso-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,8 @@ dependencies = [
  "pallet-balances",
  "pallet-beefy",
  "pallet-beefy-mmr",
+ "pallet-chainbridge",
+ "pallet-chainbridge-handler",
  "pallet-fuso-foundation",
  "pallet-fuso-reward",
  "pallet-fuso-token",
@@ -2005,14 +2007,15 @@ dependencies = [
 
 [[package]]
 name = "fuso-support"
-version = "4.0.1-release"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18-rum.7#951e8381bdeff53f299595a503f6f6078842536c"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
  "bit-vec",
  "byteorder",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -2021,8 +2024,8 @@ dependencies = [
 
 [[package]]
 name = "fuso-verifier-rpc"
-version = "4.0.1-release"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18-rum.7#951e8381bdeff53f299595a503f6f6078842536c"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2038,8 +2041,8 @@ dependencies = [
 
 [[package]]
 name = "fuso-verifier-runtime-api"
-version = "4.0.1-release"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18-rum.7#951e8381bdeff53f299595a503f6f6078842536c"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4286,9 +4289,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-chainbridge"
+version = "0.1.0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "fuso-support",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-chainbridge-handler"
+version = "0.1.0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "fuso-support",
+ "hex",
+ "log",
+ "pallet-chainbridge",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-fuso-foundation"
-version = "4.0.1-release"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18-rum.7#951e8381bdeff53f299595a503f6f6078842536c"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4306,8 +4346,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-fuso-reward"
-version = "4.0.1-release"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18-rum.7#951e8381bdeff53f299595a503f6f6078842536c"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4324,8 +4364,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-fuso-token"
-version = "4.0.1-release"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18-rum.7#951e8381bdeff53f299595a503f6f6078842536c"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4345,8 +4385,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-fuso-verifier"
-version = "4.0.1-release"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18-rum.7#951e8381bdeff53f299595a503f6f6078842536c"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.1#659e42305c7d35aa3de60236639a10f02e5b7eb6"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4317,6 +4317,7 @@ dependencies = [
  "hex",
  "log",
  "pallet-chainbridge",
+ "pallet-fuso-verifier",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
@@ -4329,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4348,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4366,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4387,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.3#5924048cb1d8d2f5bf4c7316d47b619dc02b4706"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.1#b368710083c49abf19d16c37f96e5e9e7dcb4360"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,6 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2026,7 +2025,6 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2043,7 +2041,6 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4292,7 +4289,6 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4310,7 +4306,6 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4331,11 +4326,11 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-agent"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-support",
  "frame-system",
  "fuso-support",
+ "log",
  "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4350,7 +4345,6 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4369,7 +4363,6 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4387,7 +4380,6 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4408,7 +4400,6 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ dependencies = [
  "pallet-beefy-mmr",
  "pallet-chainbridge",
  "pallet-chainbridge-handler",
+ "pallet-fuso-agent",
  "pallet-fuso-foundation",
  "pallet-fuso-reward",
  "pallet-fuso-token",
@@ -2008,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2025,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2042,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4291,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4309,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4328,9 +4329,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-fuso-agent"
+version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "fuso-support",
+ "pallet-balances",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4349,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4367,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4388,14 +4408,13 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.chainbridge.3#bd2f6751c3bc4b4eae118b98e268f2a2896e6fcb"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=feature/pallet-agent#6a38b4819610af5fda3fa42985873181b5eac9da"
 dependencies = [
  "ascii",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "fuso-support",
- "hex",
  "log",
  "pallet-balances",
  "pallet-fuso-token",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,6 +2009,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2025,6 +2026,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2041,6 +2043,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4289,6 +4292,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4306,6 +4310,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4326,6 +4331,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-agent"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4345,6 +4351,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4363,6 +4370,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4380,6 +4388,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4400,6 +4409,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4331,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-agent"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#48082a6e623a7719575ba6107e3774c9edae22d0"
+source = "git+https://github.com/uinb/fusotao-protocol.git?branch=polkadot-v0.9.18#5f161a1c51ebb3da1bd3268f221922600031a5b3"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "fuso-support"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-rpc"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "fuso-verifier-runtime-api",
  "jsonrpc-core",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "fuso-verifier-runtime-api"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4309,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "pallet-chainbridge-handler"
 version = "0.1.0"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-foundation"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-reward"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-token"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "ascii",
  "frame-benchmarking",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "pallet-fuso-verifier"
 version = "4.0.2"
-source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#f70b5a3f03cf146699cf237bc0919db838cfafb2"
+source = "git+https://github.com/uinb/fusotao-protocol.git?tag=v0.9.18.final.2#ce258183be9993ee5283e1dd6c5f3856273ed2b0"
 dependencies = [
  "ascii",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18-rum.7", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }
@@ -54,7 +54,6 @@ frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', bran
 sp-block-builder = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18' }
 sp-blockchain = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18' }
 sp-api = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18' }
-
 beefy-gadget = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
 beefy-gadget-rpc = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
 beefy-primitives = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ jsonrpc-core = '18.0.0'
 structopt = '0.3.25'
 
 fuso-runtime = { path = '../runtime' }
-fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "fuso-verifier-rpc" }
+fuso-verifier-rpc = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "fuso-verifier-rpc" }
 
 clap = { version = "3.0", features = ["derive"] }
 sc-cli = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["wasmtime"] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,15 +67,15 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
 # fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-reward" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "fuso-verifier-runtime-api" }
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-reward" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "fuso-verifier-runtime-api" }
 # chainbridge dependencies
-pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-chainbridge" }
-pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-chainbridge-handler" }
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,16 +67,16 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
 # fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-reward" }
-pallet-fuso-agent = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-agent" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "fuso-verifier-runtime-api" }
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-reward" }
+pallet-fuso-agent = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-agent" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "fuso-verifier-runtime-api" }
 # chainbridge dependencies
-pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-chainbridge" }
-pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-chainbridge-handler" }
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -54,27 +54,28 @@ pallet-session = { version = "4.0.0-dev", default-features = false, git = "https
 pallet-uniques = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
 sp-consensus-babe = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
 sp-staking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
-
+# octopus dependencies
 pallet-octopus-appchain = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", tag = "v0.9.18-3" }
 pallet-octopus-lpos = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", tag = "v0.9.18-3" }
 pallet-octopus-upward-messages = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", tag = "v0.9.18-3" }
-
-# Used for the node template's RPCs
+# Used for the RPCs
 frame-system-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
-
 # Used for runtime benchmarking
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", optional = true }
 frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", optional = true }
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
-#fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18-rum.7", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18-rum.7", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18-rum.7", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18-rum.7", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18-rum.7", default-features = false, package = "pallet-fuso-reward" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18-rum.7", default-features = false, package = "fuso-verifier-runtime-api" }
+# fusotao dependencies
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-reward" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "fuso-verifier-runtime-api" }
+# chainbridge dependencies
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -139,5 +139,6 @@ runtime-benchmarks = [
 	"pallet-timestamp/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	'pallet-fuso-verifier/runtime-benchmarks',
+	'pallet-chainbridge/runtime-benchmarks'
 ]
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,15 +67,15 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
 # fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-fuso-reward" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "fuso-verifier-runtime-api" }
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-reward" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "fuso-verifier-runtime-api" }
 # chainbridge dependencies
-pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-chainbridge" }
-pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.1", default-features = false, package = "pallet-chainbridge-handler" }
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,16 +67,16 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
 # fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-reward" }
-pallet-fuso-agent = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-fuso-agent" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "fuso-verifier-runtime-api" }
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "pallet-fuso-reward" }
+pallet-fuso-agent = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "pallet-fuso-agent" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "fuso-verifier-runtime-api" }
 # chainbridge dependencies
-pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-chainbridge" }
-pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "feature/pallet-agent", default-features = false, package = "pallet-chainbridge-handler" }
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", branch = "polkadot-v0.9.18", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,15 +67,15 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
 # fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-reward" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "fuso-verifier-runtime-api" }
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-fuso-reward" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "fuso-verifier-runtime-api" }
 # chainbridge dependencies
-pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-chainbridge" }
-pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-chainbridge-handler" }
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.1", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,15 +67,15 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
 # fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-fuso-reward" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "fuso-verifier-runtime-api" }
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-fuso-reward" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "fuso-verifier-runtime-api" }
 # chainbridge dependencies
-pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-chainbridge" }
-pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.2", default-features = false, package = "pallet-chainbridge-handler" }
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.final.3", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -67,15 +67,16 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 hex-literal = { version = "0.3.4", optional = true }
 pallet-multisig = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.18', default-features = false }
 # fusotao dependencies
-fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "fuso-support" }
-pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-verifier" }
-pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-token" }
-pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-foundation" }
-pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-fuso-reward" }
-fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "fuso-verifier-runtime-api" }
+fuso-support = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "fuso-support" }
+pallet-fuso-verifier = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-verifier" }
+pallet-fuso-token = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-token" }
+pallet-fuso-foundation = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-foundation" }
+pallet-fuso-reward = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-reward" }
+pallet-fuso-agent = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-fuso-agent" }
+fuso-verifier-runtime-api = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "fuso-verifier-runtime-api" }
 # chainbridge dependencies
-pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-chainbridge" }
-pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.chainbridge.3", default-features = false, package = "pallet-chainbridge-handler" }
+pallet-chainbridge = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-chainbridge" }
+pallet-chainbridge-handler = { git = "https://github.com/uinb/fusotao-protocol.git", tag = "v0.9.18.agent.1", default-features = false, package = "pallet-chainbridge-handler" }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
@@ -138,7 +139,7 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	'pallet-fuso-verifier/runtime-benchmarks',
-	'pallet-chainbridge/runtime-benchmarks'
+	"pallet-fuso-verifier/runtime-benchmarks",
+	"pallet-chainbridge/runtime-benchmarks",
 ]
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -805,7 +805,6 @@ construct_runtime!(
 		Reward: pallet_fuso_reward,
 		Agent: pallet_fuso_agent::<EthInstance>,
 		Verifier: pallet_fuso_verifier,
-		Agent: pallet_fuso_agent::<EthInstance>,
 	}
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 135,
+	spec_version: 136,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -643,14 +643,15 @@ impl pallet_chainbridge_handler::Config for Runtime {
 	type NativeTokenMaxValue = NativeTokenMaxValue;
 }
 
-parameter_types! {
+//use EthChainId to replace
+/*parameter_types! {
 	pub const ETHChainId: u16 = 1;
-}
+}*/
 
 impl pallet_fuso_agent::Config<pallet_fuso_agent::EthInstance> for Runtime {
 	type Currency = Balances;
 	type Event = Event;
-	type ExternalChainId = ETHChainId;
+	type ExternalChainId = EthChainId;
 	type ExternalSignWrapper = pallet_fuso_agent::EthPersonalSignWrapper;
 	type Transaction = Call;
 	type TransactionByteFee = TransactionByteFee;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,6 +36,7 @@ pub use frame_support::{
 };
 use frame_support::{weights::DispatchClass, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
+pub use fuso_support::derive_resource_id;
 pub use pallet_balances::Call as BalancesCall;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_mmr_primitives as mmr;
@@ -50,7 +51,6 @@ use sp_runtime::{
 	transaction_validity::TransactionPriority,
 	FixedPointNumber, Perquintill,
 };
-pub use fuso_support::derive_resource_id;
 pub use sp_runtime::{Perbill, Permill};
 use static_assertions::const_assert;
 
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 129,
+	spec_version: 130,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,7 +6,6 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use pallet_fuso_agent::EthInstance;
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 133,
+	spec_version: 134,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -635,6 +635,20 @@ impl pallet_chainbridge_handler::Config for Runtime {
 }
 
 parameter_types! {
+	pub const ETHChainId: u16 = 1;
+}
+
+impl pallet_fuso_agent::Config<pallet_fuso_agent::EthInstance> for Runtime {
+	type Currency = Balances;
+	type Event = Event;
+	type ExternalChainId = ETHChainId;
+	type ExternalSignWrapper = pallet_fuso_agent::EthPersonalSignWrapper;
+	type Transaction = Call;
+	type TransactionByteFee = TransactionByteFee;
+	type WeightToFee = IdentityFee<Balance>;
+}
+
+parameter_types! {
 	pub const OctopusAppchainPalletId: PalletId = PalletId(*b"py/octps");
 	pub const GracePeriod: u32 = 10;
 	pub const UnsignedPriority: u64 = 1 << 21;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 134,
+	spec_version: 135,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@ pub use frame_support::{
 };
 use frame_support::{weights::DispatchClass, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
-pub use fuso_support::derive_resource_id;
+pub use fuso_support::chainbridge::derive_resource_id;
 pub use pallet_balances::Call as BalancesCall;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_mmr_primitives as mmr;
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 130,
+	spec_version: 131,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -614,7 +614,7 @@ impl pallet_chainbridge::Config for Runtime {
 }
 
 parameter_types! {
-	pub NativeResourceId: fuso_support::chainbridge::ResourceId = fuso_support::derive_resource_id(FusotaoChainId::get(), b"TAO".as_ref()).unwrap();
+	pub NativeResourceId: fuso_support::chainbridge::ResourceId = derive_resource_id(FusotaoChainId::get(), 0, b"TAO".as_ref()).unwrap();
 	pub NativeTokenMaxValue: Balance = 0;
 	pub DonorAccount: AccountId = AccountId::new([0u8; 32]);
 	pub DonationForAgent: Balance = 100 * CENTS;
@@ -622,7 +622,8 @@ parameter_types! {
 
 impl pallet_chainbridge_handler::Config for Runtime {
 	type Event = Event;
-	type Call = Call;
+	type Redirect = Call;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type Currency = Balances;
 	type Fungibles = Token;
 	type AssetBalance = Balance;
@@ -746,6 +747,7 @@ const_assert!(DAYS % 20 == 0);
 impl pallet_fuso_verifier::Config for Runtime {
 	type Event = Event;
 	type Asset = Token;
+	type Callback = Call;
 	type Rewarding = Reward;
 	type WeightInfo = ();
 	type DominatorOnlineThreshold = DominatorOnlineThreshold;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -601,7 +601,7 @@ impl pallet_fuso_token::Config for Runtime {
 }
 
 parameter_types! {
-	pub const FusotaoChainId: u8 = 42;
+	pub const FusotaoChainId: u16 = 42;
 	pub const ProposalLifetime: BlockNumber = HOURS;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,7 +36,7 @@ pub use frame_support::{
 };
 use frame_support::{weights::DispatchClass, PalletId};
 use frame_system::limits::{BlockLength, BlockWeights};
-pub use fuso_support::chainbridge::derive_resource_id;
+use fuso_support::{chainbridge::derive_resource_id, ChainId};
 pub use pallet_balances::Call as BalancesCall;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_mmr_primitives as mmr;
@@ -589,12 +589,21 @@ impl frame_system::offchain::AppCrypto<<Signature as Verify>::Signer, Signature>
 
 parameter_types! {
 	pub const NativeTokenId: u32 = 0;
+	pub const NearChainId: ChainId = 255;
+	pub const EthChainId: ChainId = 5;
+	pub const BnbChainId: ChainId = 10;
+	pub const NativeChainId: ChainId = 42;
+
 }
 
 pub type TokenId = u32;
 
 impl pallet_fuso_token::Config for Runtime {
 	type Event = Event;
+	type BnbChainId = BnbChainId;
+	type EthChainId = EthChainId;
+	type NativeChainId = NativeChainId;
+	type NearChainId = NearChainId;
 	type TokenId = TokenId;
 	type NativeTokenId = NativeTokenId;
 	type Weight = pallet_fuso_token::weights::SubstrateWeight<Runtime>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 136,
+	spec_version: 128,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -590,7 +590,7 @@ impl frame_system::offchain::AppCrypto<<Signature as Verify>::Signer, Signature>
 parameter_types! {
 	pub const NativeTokenId: u32 = 0;
 	pub const NearChainId: ChainId = 255;
-	pub const EthChainId: ChainId = 5;
+	pub const EthChainId: ChainId = 1;
 	pub const BnbChainId: ChainId = 10;
 	pub const NativeChainId: ChainId = 42;
 
@@ -642,11 +642,6 @@ impl pallet_chainbridge_handler::Config for Runtime {
 	type NativeResourceId = NativeResourceId;
 	type NativeTokenMaxValue = NativeTokenMaxValue;
 }
-
-//use EthChainId to replace
-/*parameter_types! {
-	pub const ETHChainId: u16 = 1;
-}*/
 
 impl pallet_fuso_agent::Config<pallet_fuso_agent::EthInstance> for Runtime {
 	type Currency = Balances;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 127,
+	spec_version: 128,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -600,6 +600,41 @@ impl pallet_fuso_token::Config for Runtime {
 }
 
 parameter_types! {
+	pub const FusotaoChainId: u8 = 42;
+	pub const ProposalLifetime: BlockNumber = HOURS;
+}
+
+impl pallet_chainbridge::Config for Runtime {
+	type Event = Event;
+	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type ChainId = FusotaoChainId;
+	type Proposal = Call;
+	type ProposalLifetime = ProposalLifetime;
+}
+
+parameter_types! {
+	pub NativeResourceId: fuso_support::chainbridge::ResourceId = pallet_chainbridge::derive_resource_id(FusotaoChainId::get(), b"TAO".as_ref());
+	pub NativeTokenMaxValue: Balance = 0;
+	pub DonorAccount: AccountId = AccountId::new([0u8; 32]);
+	pub DonationForAgent: Balance = 100 * CENTS;
+}
+
+impl pallet_chainbridge_handler::Config for Runtime {
+	type Event = Event;
+	type Call = Call;
+	type Currency = Balances;
+	type Fungibles = Token;
+	type AssetBalance = Balance;
+	type AssetId = TokenId;
+	type AssetIdByName = Token;
+	type BridgeOrigin = pallet_chainbridge::EnsureBridge<Runtime>;
+	type DonationForAgent = DonationForAgent;
+	type DonorAccount = DonorAccount;
+	type NativeResourceId = NativeResourceId;
+	type NativeTokenMaxValue = NativeTokenMaxValue;
+}
+
+parameter_types! {
 	pub const OctopusAppchainPalletId: PalletId = PalletId(*b"py/octps");
 	pub const GracePeriod: u32 = 10;
 	pub const UnsignedPriority: u64 = 1 << 21;
@@ -750,6 +785,8 @@ construct_runtime!(
 		Sudo: pallet_sudo,
 		Foundation: pallet_fuso_foundation,
 		Token: pallet_fuso_token,
+		ChainBridge: pallet_chainbridge,
+		ChainBridgeHandler: pallet_chainbridge_handler,
 		Reward: pallet_fuso_reward,
 		Verifier: pallet_fuso_verifier,
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use pallet_fuso_agent::EthInstance;
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -804,6 +805,7 @@ construct_runtime!(
 		ChainBridgeHandler: pallet_chainbridge_handler,
 		Reward: pallet_fuso_reward,
 		Verifier: pallet_fuso_verifier,
+		Agent: pallet_fuso_agent::<EthInstance>,
 	}
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 132,
+	spec_version: 133,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -803,6 +803,7 @@ construct_runtime!(
 		ChainBridge: pallet_chainbridge,
 		ChainBridgeHandler: pallet_chainbridge_handler,
 		Reward: pallet_fuso_reward,
+		Agent: pallet_fuso_agent::<EthInstance>,
 		Verifier: pallet_fuso_verifier,
 	}
 );

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 131,
+	spec_version: 132,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -623,11 +623,9 @@ parameter_types! {
 impl pallet_chainbridge_handler::Config for Runtime {
 	type Event = Event;
 	type Redirect = Call;
+	type BalanceConversion = Token;
 	type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
-	type Currency = Balances;
 	type Fungibles = Token;
-	type AssetBalance = Balance;
-	type AssetId = TokenId;
 	type AssetIdByName = Token;
 	type BridgeOrigin = pallet_chainbridge::EnsureBridge<Runtime>;
 	type DonationForAgent = DonationForAgent;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -50,6 +50,7 @@ use sp_runtime::{
 	transaction_validity::TransactionPriority,
 	FixedPointNumber, Perquintill,
 };
+pub use fuso_support::derive_resource_id;
 pub use sp_runtime::{Perbill, Permill};
 use static_assertions::const_assert;
 
@@ -613,7 +614,7 @@ impl pallet_chainbridge::Config for Runtime {
 }
 
 parameter_types! {
-	pub NativeResourceId: fuso_support::chainbridge::ResourceId = pallet_chainbridge::derive_resource_id(FusotaoChainId::get(), b"TAO".as_ref());
+	pub NativeResourceId: fuso_support::chainbridge::ResourceId = fuso_support::derive_resource_id(FusotaoChainId::get(), b"TAO".as_ref()).unwrap();
 	pub NativeTokenMaxValue: Balance = 0;
 	pub DonorAccount: AccountId = AccountId::new([0u8; 32]);
 	pub DonationForAgent: Balance = 100 * CENTS;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 128,
+	spec_version: 129,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
- integrate with chainbridge
- bump version
- add runtime-benchmarks for chainbridge
- bump v0.9.18-chainbridge.10
- bump v0.9.18-chainbridge.10
- bump v0.9.18-chainbridge.11
- bump v0.9.18-chainbridge.12
- bump v0.9.18-chainbridge.13
- test agent
- enable agent
- config runtime
- fix compile error
- remove unused import
- update
- update deps
- merge
- update dpes
- update spec version
- bump v0.9.18-chainbridge.15
- update to 136
- integrate with chainbridge
